### PR TITLE
Do not use configure_plan

### DIFF
--- a/bluesky_config/ipython/profile_default/startup/00-base.py
+++ b/bluesky_config/ipython/profile_default/startup/00-base.py
@@ -18,7 +18,7 @@ from bluesky_kafka import Publisher as kafkaPublisher
 
 from bluesky_adaptive.per_start import adaptive_plan
 
-from bluesky_queueserver.plan import configure_plan
+#from bluesky_queueserver.plan import configure_plan
 
 import databroker
 import happi
@@ -97,11 +97,11 @@ from_brains = RedisQueue(redis.StrictRedis(host="localhost", port=6379, db=0))
 
 
 devs = {v.name: v for v in [happi.loader.from_container(_) for _ in hclient.all_items]}
-queue_server_plan = configure_plan(
-    devs,
-    {"count": bp.count, "scan": bp.scan},
-    "http://0.0.0.0:8081",
-)
+#queue_server_plan = configure_plan(
+#    devs,
+#    {"count": bp.count, "scan": bp.scan},
+#    "http://0.0.0.0:8081",
+#)
 
 ip.user_ns.update(devs)
 


### PR DESCRIPTION
This is a draft PR to gradually fix it to work with the latest API changes in `bluesky-queueserver` by @dmgav.

Potentially closes #15.

cc @cryos 