### PR TITLE
update branch name on bluesky-queueserver to main

### DIFF
--- a/image_builders/build_bluesky_image.sh
+++ b/image_builders/build_bluesky_image.sh
@@ -6,7 +6,7 @@ set -o xtrace
 container=$(buildah from bluesky-base)
 buildah run $container -- pip3 install nslsii
 buildah run $container -- pip3 install git+https://github.com/bluesky/bluesky-adaptive.git@master#egg=bluesky-adaptive
-buildah run $container -- pip3 install git+https://github.com/bluesky/bluesky-queueserver.git@master#egg=bluesky-queueserver
+buildah run $container -- pip3 install git+https://github.com/bluesky/bluesky-queueserver.git@main#egg=bluesky-queueserver
 buildah run $container -- pip3 install git+https://github.com/pcdshub/happi.git@master#egg=happi
 
 buildah run $container -- pip3 uninstall --yes pyepics


### PR DESCRIPTION
the main branch on bluesky-queueserver has been renamed to main. fix this - build of build_bluesky_image.sh now proceeds as expected