### PR TITLE
Add jupyter pod

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ bash image_builders/build_bluesky_image.sh
 bash image_builders/build_caproto_image.sh
 # build an image for the databroker server
 bash image_builders/build_databroker_server_image.sh
+# build an image for the jupyter single-user server
+bash image_builders/build_jupyter_image.sh
 # build an image with pydm / typhos installed
 bash image_builders/build_typhos_image.sh
 ```

--- a/dashboard_template.ipynb
+++ b/dashboard_template.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Voilà Dashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "uid = \"...\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "...\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(uid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from databroker import catalog"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog[\"MAD\"][uid].primary.read()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog[\"MAD\"][uid].primary.read().plot.scatter(x=\"motor\", y=\"det1\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/dashboard_template.ipynb
+++ b/dashboard_template.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "parameters"
@@ -17,24 +17,26 @@
    },
    "outputs": [],
    "source": [
+    "# This is the parameters cell.\n",
     "uid = \"...\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "...\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(uid)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget"
    ]
   },
   {

--- a/image_builders/build_jupyter_image.sh
+++ b/image_builders/build_jupyter_image.sh
@@ -1,0 +1,11 @@
+#! /usr/bin/bash
+set -e
+set -o xtrace
+
+
+container=$(buildah from bluesky)
+buildah run $container -- pip3 install jupyterlab voila
+buildah run $container -- jupyter serverextension enable voila --sys-prefix
+buildah config --cmd "jupyter lab --no-browser --allow-root --NotebookApp.token=''" $container
+buildah unmount $container
+buildah commit $container jupyter

--- a/image_builders/build_jupyter_image.sh
+++ b/image_builders/build_jupyter_image.sh
@@ -5,7 +5,7 @@ set -o xtrace
 
 container=$(buildah from bluesky)
 buildah run $container -- python3 -c "import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot"  # Build font cache.
-buildah run $container -- pip3 install jupyterlab voila papermill
+buildah run $container -- pip3 install jupyterlab voila papermill ipympl databroker bluesky-live
 buildah run $container -- pip3 install git+https://github.com/danielballan/papermillhub
 buildah run $container -- jupyter serverextension enable voila --sys-prefix
 buildah run $container -- jupyter serverextension enable papermillhub.nbext --sys-prefix

--- a/image_builders/build_jupyter_image.sh
+++ b/image_builders/build_jupyter_image.sh
@@ -4,8 +4,15 @@ set -o xtrace
 
 
 container=$(buildah from bluesky)
-buildah run $container -- pip3 install jupyterlab voila
+buildah run $container -- python3 -c "import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot"  # Build font cache.
+buildah run $container -- pip3 install jupyterlab voila papermill
+buildah run $container -- pip3 install git+https://github.com/danielballan/papermillhub
 buildah run $container -- jupyter serverextension enable voila --sys-prefix
-buildah config --cmd "jupyter lab --no-browser --allow-root --NotebookApp.token=''" $container
+buildah run $container -- jupyter serverextension enable papermillhub.nbext --sys-prefix
+buildah run $container -- dnf install -y nodejs
+buildah run $container -- jupyter labextension install @jupyter-widgets/jupyterlab-manager
+buildah run $container -- jupyter labextension install jupyter-matplotlib
+buildah run $container -- jupyter labextension install @jupyter-voila/jupyterlab-preview
+buildah config --cmd "jupyter lab --no-browser --allow-root --NotebookApp.token='dev'" $container
 buildah unmount $container
 buildah commit $container jupyter

--- a/start_databroker_pod.sh
+++ b/start_databroker_pod.sh
@@ -6,7 +6,7 @@ IP_ADDR=`ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*
 
 ########################################################################################################################
 # Dataaccess pod.
-podman pod create -n databroker -p 6942:9090/tcp
+podman pod create -n databroker -p 6942:9090/tcp -p 8888:8888/tcp
 # start up a mongo
 podman run -dt --pod databroker --rm mongo
 # listen to kafka published from the other pod
@@ -46,3 +46,7 @@ podman run --pod databroker \
        --name=db_reverse_proxy \
        -dt --rm \
        $NGINX_CONTAINER
+
+podman run -dt --pod databroker --rm \
+    -v ./bluesky_config/databroker:/usr/local/share/intake \
+    jupyter

--- a/start_databroker_pod.sh
+++ b/start_databroker_pod.sh
@@ -6,7 +6,7 @@ IP_ADDR=`ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*
 
 ########################################################################################################################
 # Dataaccess pod.
-podman pod create -n databroker -p 6942:9090/tcp -p 8888:8888/tcp
+podman pod create -n databroker -p 6942:9090/tcp -p 9999:8888/tcp
 # start up a mongo
 podman run -dt --pod databroker --rm mongo
 # listen to kafka published from the other pod

--- a/start_jupyter_pod.sh
+++ b/start_jupyter_pod.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/bash
+set -e
+set -o xtrace
+
+podman pod create -n jupyter -p 8888:8888/tcp
+podman run -dt --pod jupyter --rm jupyter

--- a/start_jupyter_pod.sh
+++ b/start_jupyter_pod.sh
@@ -1,6 +1,0 @@
-#! /usr/bin/bash
-set -e
-set -o xtrace
-
-podman pod create -n jupyter -p 8888:8888/tcp
-podman run -dt --pod jupyter --rm jupyter


### PR DESCRIPTION
This adds an image running a Jupyter "single-user server" --- that is `jupyter lab ...`, not involving JupyterHub. It is run in the `databroker` pod so that it has access to MongoDB.

The server is configured with the authorization token hard-coded to `dev`. Therefore, it will accept requests with the HTTP header `Authorization:token dev`.

The server is extended by:
* voila
* papermillhub

The front-end (JupyterLab) is extended by:
* Jupyter widgets
* matplotlib Jupyter widgets integration for interactive plots
* Voila for interactive dashboard rendering
 
This PR also includes a dashboard template notebook, which can be used like so:

```   
# Upload the template to the Jupyter server.
http put http://localhost:9999/api/contents/dashboard_template.ipynb "Authorization:token dev" content:=@dashboard_template.ipynb type=notebook

# Generate a dashboard for a given UID.
http http://localhost:9999/papermillhub/ "Authorization:token dev" in_path=dashboard_template.ipynb out_path=dashboard_$UID.ipynb parameters:='{​​​​​​​"uid": "$UID"}​​​​​​​'
```

Navigate to `http://localhost:9999/voila/render/dashboard_$UID.ipynb` to view the dashboard.
Navigate to `http://localhost:9999/lab/tree/dashboard_$UID.ipynb` to interactively customize the dashboard (or just work in the notebook).