### PR TITLE
Voila material UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bluesky_config/**/log/
 bluesky_config/**/pid/
 __pycache__
 image_builders/pip_cache
+.ipynb_checkpoints/

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ bash image_builders/build_bluesky_snapshot.sh
 bash start_core_pods.sh
 ```
 
+## Generate some example data quickly
+
+```
+podman run --rm --pod acquisition -v ./data_generation_scripts:/data_generation_scripts bluesky bash /data_generation_scripts/generate_example_data.sh
+```
+
 ## Launch bsui (bluesky ipython terminal)
 
 Run

--- a/dashboard_template.ipynb
+++ b/dashboard_template.ipynb
@@ -65,6 +65,60 @@
    "source": [
     "catalog[\"MAD\"][uid].primary.read().plot.scatter(x=\"motor\", y=\"det1\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Some meaningless widgets as a placeholder for something useful...."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import IntSlider, IntText, link, HBox, VBox, Checkbox"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = IntSlider(50, 0, 109)\n",
+    "t = IntText()\n",
+    "link((x, 'value'), (t, 'value'))\n",
+    "HBox([x, t])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "VBox([Checkbox(True, description=\"A\"), Checkbox(False, description=\"B\"), Checkbox(True, description=\"C\")])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import ToggleButton\n",
+    "ToggleButton(description=\"Toggle Me\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/data_generation_scripts/generate_example_data.sh
+++ b/data_generation_scripts/generate_example_data.sh
@@ -1,0 +1,5 @@
+qserver -c environment_open
+qserver -c queue_plan_add -p '{"name":"count", "args":[["det1", "det2"]]}'
+qserver -c queue_plan_add -p '{"name":"scan", "args":[["det1", "det2"], "motor", -1, 1, 10]}'
+qserver -c queue_start
+# TODO Any way to wait until the queue is empty and then close the environment?

--- a/image_builders/build_jupyter_image.sh
+++ b/image_builders/build_jupyter_image.sh
@@ -5,7 +5,7 @@ set -o xtrace
 
 container=$(buildah from bluesky)
 buildah run $container -- python3 -c "import matplotlib; matplotlib.use('Agg'); import matplotlib.pyplot"  # Build font cache.
-buildah run $container -- pip3 install jupyterlab voila papermill ipympl databroker bluesky-live
+buildah run $container -- pip3 install jupyterlab voila voila-material papermill ipympl databroker bluesky-live
 buildah run $container -- pip3 install git+https://github.com/danielballan/papermillhub
 buildah run $container -- jupyter serverextension enable voila --sys-prefix
 buildah run $container -- jupyter serverextension enable papermillhub.nbext --sys-prefix
@@ -13,6 +13,6 @@ buildah run $container -- dnf install -y nodejs
 buildah run $container -- jupyter labextension install @jupyter-widgets/jupyterlab-manager
 buildah run $container -- jupyter labextension install jupyter-matplotlib
 buildah run $container -- jupyter labextension install @jupyter-voila/jupyterlab-preview
-buildah config --cmd "jupyter lab --no-browser --allow-root --NotebookApp.token='dev'" $container
+buildah config --cmd "jupyter lab --no-browser --allow-root --NotebookApp.token='dev' --VoilaConfiguration.enable_nbextensions=True --VoilaConfiguration.template='material'" $container
 buildah unmount $container
 buildah commit $container jupyter


### PR DESCRIPTION
The Voila ecosystem includes [a Material UI template](https://github.com/voila-dashboards/voila-material/) supported by the core team. This matches the dashboard to the look and feel of the databroker-client.

![image](https://user-images.githubusercontent.com/2279598/97457510-32f4b080-1910-11eb-8d56-1381baadf10b.png)

This PR also includes some scripts for generating some example Runs quickly from the command line which is useful for development of databroker-server and things downstream of it.