### PR TITLE
ENH: add building + launcher for xpdan

### DIFF
--- a/bluesky_config/databroker/omnia.yml
+++ b/bluesky_config/databroker/omnia.yml
@@ -1,0 +1,17 @@
+sources:
+  omnia:
+    args:
+      paths:
+      - /data/omnia/*.msgpack
+      root_map:
+        /nsls2/xf28id1/data/pe1_data: /data/omnia/nsls2/xf28id1/data/pe1_data
+        f6f129302c62494e1347c262ddb09c0f: /data/omnia/nsls2/xf28id1/data/pe1_data
+      handler_registry:
+        AD_TIFF: databroker.assets.handlers.AreaDetectorTiffHandler
+    driver: bluesky-msgpack-catalog
+    metadata:
+      generated_by:
+        library: databroker_pack
+        version: 0.1.3
+      relative_paths:
+      - ./*.msgpack

--- a/bluesky_config/xpdacq/acq/mad.yml
+++ b/bluesky_config/xpdacq/acq/mad.yml
@@ -1,0 +1,35 @@
+archive_base_dir_name: .userbeamtimearchive
+archive_root_dir: /data/xpdacq_archive
+base_dir: /data/xpdacq_data
+beamline_host_name: []
+beamline_id: 28-ID-1
+blconfig_dir_name: xpdConfig
+blconfig_name: xpd_beamline_config.yml
+calib_config_name: xpdAcq_calib_info.yml
+dark_window: 0.1
+facility: NSLS-II
+frame_acquire_time: 0.1
+glbl_yaml_name: glbl.yml
+group: XPD
+home_dir_name: user_data
+image_field: pe1c_image
+owner: PDF
+simulation: false
+shutter_conf: {close: 0, open: 1}
+mask_kwargs:
+  edge: 30
+  lower_thresh: 0.0
+  bs_width: 13
+  tri_offset: 13
+  v_asym: 0
+  alpha: 3.0
+dark_field_key : sc_dk_field_uid
+det_image_field : pe1_image
+exp_broker_name: omnia
+outbound_proxy_address: 'localhost:5678'
+inbound_proxy_address: 'localhost:4567'
+shutter_sleep: 0
+diffraction_dets: ['pe1c', 'pe1', 'pe2c', 'pe2','dexela_image', 'dexela']
+radiograph_names : ['blackfly_det']
+radiogram_dets: ['blackfly_det']
+image_fields: ['pe1c_image', 'pe2c_image', 'dexela_image', 'dexela']

--- a/image_builders/build_xpdan.sh
+++ b/image_builders/build_xpdan.sh
@@ -1,0 +1,20 @@
+
+#! /usr/bin/bash
+set -e
+set -o xtrace
+
+
+container=$(buildah from condaforge/miniforge3)
+# set up some config
+buildah run $container -- apt update
+buildah run $container -- apt-get --yes install mesa-utils patch
+buildah run $container -- conda config --set always_yes yes --set changeps1 no --set quiet true
+# pull the source from
+
+buildah run $container -- conda create -n bluesky -c nsls2forge -c defaults --no-channel-priority --override-channels bluesky python=3.7 xpdan tomopy tqdm area-detector-handlers
+
+buildah run -v `pwd`/image_builders/xpdan_patches:/patches $container -- bash -c "patch -d /opt/conda/envs/bluesky/lib/python3.7/site-packages/ -p1 < /patches/xpdan.patch"
+
+buildah run -v `pwd`/image_builders/xpdan_patches:/patches $container -- bash -c "patch -d /opt/conda/envs/bluesky/lib/python3.7/site-packages/ -p1 < /patches/broker.patch"
+buildah unmount $container
+buildah commit $container xpdan

--- a/image_builders/xpdan_patches/broker.patch
+++ b/image_builders/xpdan_patches/broker.patch
@@ -1,0 +1,36 @@
+diff --git a/databroker/tests/test_broker.py b/databroker/tests/test_broker.py
+index 95da7d78..b6209b4b 100644
+--- a/databroker/tests/test_broker.py
++++ b/databroker/tests/test_broker.py
+@@ -47,6 +47,18 @@ def test_uid_roundtrip(db, RE, hw):
+     assert h['start']['uid'] == uid
+ 
+ 
++def test_header_equality(db, RE, hw):
++    RE.subscribe(db.insert)
++    uid, = RE(count([hw.det]))
++    uid2, = RE(count([hw.det]))
++    h = db[uid]
++    h2 = db[uid2]
++
++    assert h != []
++    assert h != h2
++    assert h == db[uid]
++
++
+ def test_no_descriptor_name(db, RE, hw):
+     def local_insert(name, doc):
+         doc.pop('name', None)
+diff --git a/databroker/v1.py b/databroker/v1.py
+index 54c2b98e..1dfbc156 100644
+--- a/databroker/v1.py
++++ b/databroker/v1.py
+@@ -1016,6 +1016,8 @@ class Header:
+         return self.db.prepare_hook('stop', self._stop)
+ 
+     def __eq__(self, other):
++        if not isinstance(other, Header):
++            return False
+         return self.start == other.start
+ 
+     @property

--- a/image_builders/xpdan_patches/xpdan.patch
+++ b/image_builders/xpdan_patches/xpdan.patch
@@ -1,0 +1,14 @@
+diff --git a/xpdan/vend/callbacks/core.py b/xpdan/vend/callbacks/core.py
+index fd3b448..d5bc831 100644
+--- a/xpdan/vend/callbacks/core.py
++++ b/xpdan/vend/callbacks/core.py
+@@ -64,0 +64,0 @@ LiveMesh = _deprecate_import_name("LiveMesh")
+
+ class CallbackBase:
+     def __call__(self, name, doc):
++        # SHED will try to mutate documents, cast back to dict to let it.
++        if hasattr(doc, 'to_dict'):
++            doc = doc.to_dict()
+         ret = getattr(self, name)(doc)
+         if ret:
+             return name, ret

--- a/xpdacq/start_analysis_server.sh
+++ b/xpdacq/start_analysis_server.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/bash
+set -e
+set -o xtrace
+
+
+podman run --pod acquisition \
+       --rm -ti \
+       -v ./bluesky_config/xpdacq/acq:/etc/acq \
+       -v ./bluesky_config/databroker:/root/.local/share/intake \
+       -v /mnt/store/data_cache/:/data \
+       xpdan \
+       bash -c "/opt/conda/envs/bluesky/bin/analysis_server"


### PR DESCRIPTION
We have to patch databroker and xpdan to work together with the
currently release versions of both, both have been PR'd upstream
already.

This assumes that the data for omnia is mounted at
/mnt/store/data_cache/ on the host system

