### PR TITLE
minimal modification to get MongoConsumer working with new topic_data…

### DIFF
--- a/bluesky_config/scripts/mongo_consumer.py
+++ b/bluesky_config/scripts/mongo_consumer.py
@@ -34,12 +34,13 @@ bootstrap_servers = args.kafka_server
 kafka_deserializer = partial(msgpack.loads, object_hook=mpn.decode)
 auto_offset_reset = "latest"
 topics = ["^.*bluesky.documents"]
-
+topic_database_map = {"mad.bluesky.documents": "mad-bluesky-documents"}
 # Create a MongoConsumer that will automatically listen to new beamline topics.
 # The parameter metadata.max.age.ms determines how often the consumer will check for
 # new topics. The default value is 5000ms.
 settings = dict(
     topics=topics,
+    topic_database_map=topic_database_map,
     bootstrap_servers=bootstrap_servers,
     group_id=args.kafka_group,
     mongo_uri=mongo_uri,


### PR DESCRIPTION
Absolutely minimal change to add topic_database_map to MongoConsumer settings, so that mongo inserts work via kafka.

Tested by running `start_acquisition_pod.sh`, and then `launch_bluesky.sh` and running `RE(scan([det], motor, 0, 5, 5))` and verifying

```
In [9]: db
Out[9]: MAD:
  args:
    asset_registry_db: mongodb://localhost:27017/mad-bluesky-documents
    metadatastore_db: mongodb://localhost:27017/mad-bluesky-documents
    name: MAD
  description: ''
  driver: databroker._drivers.mongo_normalized.BlueskyMongoCatalog
  metadata:
    catalog_dir: /usr/local/share/intake/


In [10]: db.v2[-1].primary.read()
Mongo Entries cache found '331d433a-5ee0-4be4-942a-2e8d799dd831'
Entry cache found BlueskyRun named '331d433a-5ee0-4be4-942a-2e8d799dd831'
Entry cache found BlueskyRun named '331d433a-5ee0-4be4-942a-2e8d799dd831'
Loaded BlueskyRun named '331d433a-5ee0-4be4-942a-2e8d799dd831'
Created Entry named 'primary'
Loaded BlueskyEventStream for stream name 'primary'
Created BlueskyEventStream for stream name 'primary'
Loaded BlueskyEventStream for stream name 'primary'
Out[10]: 
<xarray.Dataset>
Dimensions:         (time: 5)
Coordinates:
  * time            (time) float64 1.699e+09 1.699e+09 ... 1.699e+09 1.699e+09
Data variables:
    det             (time) float64 1.0 0.4578 0.04394 0.0008838 3.727e-06
    motor           (time) float64 0.0 1.25 2.5 3.75 5.0
    motor_setpoint  (time) float64 0.0 1.25 2.5 3.75 5.0
```
