### PR TITLE
maint: create OS dependent display variables in launch script for bsui

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ To get a bluesky terminal in this pod run
 bash launch_bluesky.sh
 ```
 
+On a Mac, [XQuartz](https://www.xquartz.org) is required to display the output of the Best Effort Callback. 
+
 There is a jupyterlab instance, a tiled instance, and a Queueserver http API
 instance running the pod which are proxied via nginx.  If the pod is running
 `http://localhost:11973` will provide links to each.

--- a/compose/acq-pod/launch_bluesky.sh
+++ b/compose/acq-pod/launch_bluesky.sh
@@ -2,10 +2,26 @@
 set -e
 set -o xtrace
 
+# Set up local display and xhost access on Mac or Linux
+# Check if the operating system is Mac or Linux
+if [[ "$(uname)" == "Darwin" ]]; then
+    # On a Mac, set LOCAL_DISPLAY_IP to the IP address
+    LOCAL_DISPLAY_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
+elif [[ "$(uname)" == "Linux" ]]; then
+    # On Linux, set LOCAL_DISPLAY_IP to an empty string
+    LOCAL_DISPLAY_IP=""
+fi
+# Set LOCAL_DISPLAY
+if [[ -n "$LOCAL_DISPLAY_IP" ]]; then
+    LOCAL_DISPLAY="${LOCAL_DISPLAY_IP}:0"
+else
+    LOCAL_DISPLAY="$DISPLAY"
+fi
+
 # This was a useful reference for the $DISPLAY and xauth stuff.
 # https://stackoverflow.com/a/48235281/1221924
 
-if [ -v "SSH_CONNECTION" ]; then
+if [ -z "SSH_CONNECTION" ]; then
 	echo "SSH_CONNECTION is set"
 	# Unlike the recommendation in the linked SO post,
 	# we are not using docker and thus not using docker's special network.
@@ -13,8 +29,12 @@ if [ -v "SSH_CONNECTION" ]; then
 	IP_ADDR=`ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n 1`
 	DISPLAY=`echo $DISPLAY | sed "s/^[^:]*\(.*\)/${IP_ADDR}\1/"`
 fi
-XAUTH=/tmp/.docker.xauth
-xauth nlist $DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+if [[ "$(uname)" == "Darwin" ]]; then
+    XAUTH=~/.Xauthority
+else
+    XAUTH=/tmp/.docker.xauth
+fi
+xauth nlist $LOCAL_DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
 # https://stackoverflow.com/questions/24112727/relative-paths-based-on-file-location-instead-of-current-working-directory
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
@@ -30,9 +50,9 @@ podman run --pod pod_acq-pod  \
        --network-alias sneaky \
        -ti  --rm \
        -v /tmp/.X11-unix/:/tmp/.X11-unix/ \
-       -e DISPLAY \
-       -v $XAUTH:$XAUTH \
-       -e XAUTHORITY=$XAUTH \
+       -e DISPLAY=$LOCAL_DISPLAY \
+       -v $XAUTH:/tmp/.docker.xauth \
+       -e XAUTHORITY=/tmp/.docker.xauth \
        -v `pwd`:'/app' -w '/app' \
        -v $parent_path/../../bluesky_config/ipython:/usr/local/share/ipython \
        -v $parent_path/../../bluesky_config/databroker:/usr/local/share/intake \


### PR DESCRIPTION
Adding this detail from my learnings trying to get the QT Server App running in a container on a Mac. 

Firstly, `DISPLAY` needs to be set using full local private IP on OSX. 
Secondly, `XAUTH` is in a different location. 

Prior to this, the bash script would fail because `/tmp/.docker.xauth` did not exist. On updating that to `~/.Xauthority`, the container would launch and operate, but the figures from BestEffortCallback would not get piped through to XQuartz. 

Example tested: `RE(bp.scan([det], motor, -10, 10, 15))`