### PR TITLE
fix: tiled install and mount failures

### DIFF
--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -6,6 +6,7 @@ volumes:
   data:
   mongo:
 
+
 services:
   # some simulated IOCs
   caproto-hello-world:
@@ -92,9 +93,7 @@ services:
     build: ../sub-tiled
     volumes:
       - data:/nsls2/data/mad
-      - type: bind
-        source: ../../bluesky_config/tiled
-        target: /usr/local/share/tiled
+      - ../../bluesky_config/tiled:/usr/local/share/tiled
     command: tiled serve config /usr/local/share/tiled
 
   # inserter

--- a/compose/sub-tiled/Containerfile
+++ b/compose/sub-tiled/Containerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/bluesky/databroker:latest
 
 RUN apt update
 RUN apt install git npm --yes
-RUN TILED_BUILD_PUBLIC_PATH=/tiled/ui/ pip install git+https://github.com/bluesky/tiled.git@main
+RUN TILED_BUILD_PUBLIC_PATH=/tiled/ui/ pip install tiled

--- a/compose/sub-tiled/Containerfile
+++ b/compose/sub-tiled/Containerfile
@@ -2,4 +2,4 @@ FROM ghcr.io/bluesky/databroker:latest
 
 RUN apt update
 RUN apt install git npm --yes
-RUN TILED_BUILD_PUBLIC_PATH=/tiled/ui/ pip install tiled
+RUN TILED_BUILD_PUBLIC_PATH=/tiled/ui/ pip install tiled --no-binary :all:


### PR DESCRIPTION
Direct from git main caused the tiled install to break in the container. Using the most recent release from pypi was more stable. 

Secondly, some versions of Podman/Docker compose (e.g., Podman-compose 1.0.6) don't work with relative paths using the long form bind on volumes.  