### PR TITLE
Add qt queue monitor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ bluesky_config/**/pid/
 __pycache__
 image_builders/pip_cache
 .ipynb_checkpoints/
+*.env

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ development.
 
 ```sh
 cd compose/acq_pod
+bash generate_env.sh
 podman compose --in-pod true up
 ```
 

--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -6,6 +6,7 @@ volumes:
   data:
   mongo:
 
+
 services:
   # some simulated IOCs
   caproto-hello-world:
@@ -128,7 +129,7 @@ services:
   queue_manager:
     image: bluesky
     build: ../bluesky
-    command: start-re-manager --kafka-server=kafka:29092 --zmq-publish-console ON --keep-re --redis-addr redis
+    command: start-re-manager --kafka-server=kafka:29092 --zmq-publish-console ON --redis-addr redis
     depends_on:
       kafka:
         condition: service_started
@@ -139,9 +140,23 @@ services:
     command: uvicorn --host qs_api --port 60610 bluesky_httpserver.server:app
     env:
       - QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY=mad
+      - QSERVER_ZMQ_CONTROL_ADDRESS=tcp://queue_manager:60615
+      - QSERVER_ZMQ_INFO_ADDRESS=tcp://queue_manager:60625
     depends_on:
       queue_manager:
         condition: service_started
+
+  queue-monitor:
+    image: queue-monitor
+    build: ../queue-monitor
+    environment:
+      - DISPLAY=${LOCAL_DISPLAY}
+      - QSERVER_ZMQ_CONTROL_ADDRESS=tcp://queue_manager:60615
+      - QSERVER_ZMQ_INFO_ADDRESS=tcp://queue_manager:60625
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    user: qtuser
+    # profiles: [ "qt" ] # Not supported in podman-compose as of 1.0.6
 
   proxy:
     image: docker.io/nginx

--- a/compose/acq-pod/generate_env.sh
+++ b/compose/acq-pod/generate_env.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Generate .env file for use with podman-compose
+# Sets up local xauth rules for X11 forwarding
+
+# Set up local display and xhost access on Mac or Linux
+# Check if the operating system is Mac or Linux
+if [[ "$(uname)" == "Darwin" ]]; then
+    # On a Mac, set LOCAL_DISPLAY_IP to the IP address
+    LOCAL_DISPLAY_IP=$(ifconfig en0 | grep inet | awk '$1=="inet" {print $2}')
+elif [[ "$(uname)" == "Linux" ]]; then
+    # On Linux, set LOCAL_DISPLAY_IP to an empty string
+    LOCAL_DISPLAY_IP=""
+fi
+# Set LOCAL_DISPLAY
+if [[ -n "$LOCAL_DISPLAY_IP" ]]; then
+    LOCAL_DISPLAY="${LOCAL_DISPLAY_IP}:0"
+else
+    LOCAL_DISPLAY="$DISPLAY"
+fi
+# If on a Mac, execute xhost + with LOCAL_DISPLAY_IP
+if [[ "$(uname)" == "Darwin" ]]; then
+    xhost +"$LOCAL_DISPLAY_IP"
+fi
+
+# This was a useful reference for the $DISPLAY and xauth stuff.
+# https://stackoverflow.com/a/48235281/1221924
+if [ -z "SSH_CONNECTION" ]; then
+ 	echo "SSH_CONNECTION is set"
+ 	# Unlike the recommendation in the linked SO post,
+ 	# we are not using docker and thus not using docker's special network.
+ 	# Instead, we use the IP of the host.
+ 	IP_ADDR=`ifconfig | sed -En 's/127.0.0.1//;s/.*inet (addr:)?(([0-9]*\.){3}[0-9]*).*/\2/p' | head -n 1`
+ 	LOCAL_DISPLAY=`echo $DISPLAY | sed "s/^[^:]*\(.*\)/${IP_ADDR}\1/"`
+ fi
+ if [[ "$(uname)" == "Darwin" ]]; then
+     XAUTH=~/.Xauthority
+ else
+     XAUTH=/tmp/.docker.xauth
+ fi
+ xauth nlist $LOCAL_DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
+
+echo "LOCAL_DISPLAY_IP=$LOCAL_DISPLAY_IP" > .env
+echo "LOCAL_DISPLAY=$LOCAL_DISPLAY" >> .env
+

--- a/compose/queue-monitor/Containerfile
+++ b/compose/queue-monitor/Containerfile
@@ -20,9 +20,6 @@ ENV QSERVER_ZMQ_INFO_ADDRESS=tcp://*:60625
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
-# VNC viewer
-EXPOSE 5901
-
 # Sets up and echos the environment
 ENTRYPOINT [ "/entrypoint.sh" ]
 

--- a/compose/queue-monitor/Containerfile
+++ b/compose/queue-monitor/Containerfile
@@ -1,0 +1,29 @@
+FROM jozo/pyqt5
+
+# Upgrade pip and setuptools
+RUN apt-get update \
+    && apt-get install -y \
+    python3-pip \
+    python3-setuptools \
+    python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip3 install --upgrade pip setuptools
+
+# Install bluesky-widgets and its dependencies
+RUN pip3 install bluesky-queueserver bluesky-queueserver-api
+RUN pip3 install 'bluesky-widgets[complete]'
+
+ENV QSERVER_ZMQ_CONTROL_ADDRESS=tcp://*:60615
+ENV QSERVER_ZMQ_INFO_ADDRESS=tcp://*:60625
+
+# Copy entrypoint script
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# VNC viewer
+EXPOSE 5901
+
+# Sets up and echos the environment
+ENTRYPOINT [ "/entrypoint.sh" ]
+
+CMD ["queue-monitor"]

--- a/compose/queue-monitor/entrypoint.sh
+++ b/compose/queue-monitor/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Starting queue-monitor GUI container..."
+echo "Control address: $QSERVER_ZMQ_CONTROL_ADDRESS"
+echo "Publish address: $QSERVER_ZMQ_INFO_ADDRESS"
+echo "DISPLAY: $DISPLAY"
+exec "$@"


### PR DESCRIPTION
This extracts some of the content from #46 to the creation of a .env file for the Podman-compose to consume. It then builds on a QT base image that is known to work, and spins up the app in Bluesky-widgets for monitoring and interacting with the queue server. 

Additionally, this gets explicit about the queue server address in the compose file. When testing the QT app, it became clear that the other clients of the qserver were not actually connecting even when in a common pod. Being explicit with a host name solved this. 

I'm on the fence about whether this should be merged, or wait for [this feature](https://github.com/containers/podman-compose/pull/592) to land in a tag so that we don't always spin up the QT Gui.

