### PR TITLE
Add: qt monitor as spy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ To get a bluesky terminal in this pod run
 bash launch_bluesky.sh
 ```
 
+To get a default QT gui for the queue server run
+```sh
+bash launch_bluesky.sh bluesky queue-monitor
+```
+
 On a Mac, [XQuartz](https://www.xquartz.org) is required to display the output of the Best Effort Callback. 
 
 There is a jupyterlab instance, a tiled instance, and a Queueserver http API

--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -127,7 +127,7 @@ services:
   queue_manager:
     image: bluesky
     build: ../bluesky
-    command: start-re-manager --kafka-server=kafka:29092 --zmq-publish-console ON --keep-re --redis-addr redis
+    command: start-re-manager --kafka-server=kafka:29092 --zmq-publish-console ON --redis-addr redis
     depends_on:
       kafka:
         condition: service_started
@@ -138,6 +138,8 @@ services:
     command: uvicorn --host qs_api --port 60610 bluesky_httpserver.server:app
     env:
       - QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY=mad
+      - QSERVER_ZMQ_CONTROL_ADDRESS=tcp://queue_manager:60615
+      - QSERVER_ZMQ_INFO_ADDRESS=tcp://queue_manager:60625
     depends_on:
       queue_manager:
         condition: service_started

--- a/compose/acq-pod/launch_bluesky.sh
+++ b/compose/acq-pod/launch_bluesky.sh
@@ -45,6 +45,13 @@ else
     imagename="bluesky"
 fi
 
+if [ "$2" != "" ]; then
+    CMD=$2
+else
+    CMD="ipython3 --ipython-dir=/usr/local/share/ipython"
+fi
+
+
 podman run --pod pod_acq-pod  \
        --net acq-pod_default \
        --network-alias sneaky \
@@ -61,5 +68,7 @@ podman run --pod pod_acq-pod  \
        -e EPICS_CA_ADDR_LIST=10.0.2.255 \
        -e EPICS_CA_AUTO_ADDR_LIST=no \
        -e PYTHONPATH=/usr/local/share/ipython\
+       -e QSERVER_ZMQ_CONTROL_ADDRESS=tcp://queue_manager:60615\
+       -e QSERVER_ZMQ_INFO_ADDRESS=tcp://queue_manager:60625\
        $imagename \
-       ipython3 --ipython-dir=/usr/local/share/ipython
+       $CMD \

--- a/compose/bluesky/Containerfile
+++ b/compose/bluesky/Containerfile
@@ -10,6 +10,7 @@ RUN python3 -c "import matplotlib.font_manager"  # Build font cache.
 RUN pip3 install git+https://github.com/bluesky/bluesky-adaptive.git@main#egg=bluesky-adaptive
 RUN pip3 install git+https://github.com/bluesky/bluesky-queueserver.git@main#egg=bluesky-queueserver
 RUN pip3 install git+https://github.com/bluesky/bluesky-httpserver.git@master#egg=bluesky-httpserver
+RUN pip3 install git+https://github.com/bluesky/bluesky-widgets.git@master#egg=bluesky-widgets
 RUN pip3 install git+https://github.com/pcdshub/happi.git@master#egg=happi
 RUN pip3 install nslsii
 RUN pip3 uninstall --yes pyepics


### PR DESCRIPTION
This builds upon #46. 
Closes #48. 

Uses the QT and xauth adjustments from #46 to launch the `queue-monitor` QT App using the same image as other bluesky applications. 
To do this, Bluesky-widgets was added to the bluesky image.  An optional argument was added to the `launch_bluesky.sh` script  to change the command passed to the container. Necessary env vars are also set up. 