### PR TITLE
FIX: ghcr build context

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-ghcr-build
   workflow_dispatch:
 
 env:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Build and push image to GitHub Container Registry
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./compose/bluesky
         file: ./compose/bluesky/Containerfile
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-ghcr-build
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The automatic build was missing the context of the directory, and not finding the kafka configuration. I'm unsure how it ever built on the feature branch, but this successfully built the image and placed it here:  https://github.com/maffettone/bluesky-pods/pkgs/container/bluesky-pods-bluesky/207507388?tag=fix-ghcr-build 