### PR TITLE
fix: Tiled and Databroker configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ development.
 
 ```sh
 cd compose/acq-pod
-podman compose --in-pod true up
+podman-compose --in-pod true up
 ```
 
 To get a bluesky terminal in this pod run

--- a/README.md
+++ b/README.md
@@ -20,10 +20,24 @@ To get a bluesky terminal in this pod run
 bash launch_bluesky.sh
 ```
 
+From inside `bsui` a set of simulated devices are available, as are databases and `tiled` servers.
+Data can be accessed via `databroker`, a `tiled` profile, or a remote `tiled` server.
+
+```python
+RE(scan([det], motor, -10,10,10)) # will produce a liveplot and data
+db[1] # or db[uid] can be used to access the data
+from tiled.client import from_profile, from_uri
+c = from_profile("MAD")
+c[1] # or c[uid]
+c = from_uri("http://tld:8000/")
+c[1] # or c[uid]
+```
+
 Setting the environment variable `BLUESKY_PROFILE_DIR` to an ipython profile will allow you to use a custom profile in the `launch_bluesky.sh` script or the Queue Server container.
 In both cases, the RunEngine (RE), databroker, and Kafka subscriptions must be initialized in the startup profile.
 
 To get a default QT gui for the queue server run
+
 ```sh
 bash launch_bluesky.sh bluesky queue-monitor
 ```

--- a/bluesky_config/databroker/mad-tiled.yml
+++ b/bluesky_config/databroker/mad-tiled.yml
@@ -1,0 +1,10 @@
+# Tiled Client Config
+MAD:
+  direct:
+    authentication:
+      allow_anonymous_access: true
+    trees:
+      - tree: databroker.mongo_normalized:Tree.from_uri
+        path: /
+        args:
+          uri: mongodb://mongo:27017/mad-bluesky-documents

--- a/bluesky_config/tiled/tld.yml
+++ b/bluesky_config/tiled/tld.yml
@@ -7,6 +7,7 @@ trees:
 uvicorn:
   host: 0.0.0.0
   port: 8000
+  root_path: /tiled
 authentication:
   allow_anonymous_access: true
   single_user_api_key: "ABCDABCD"

--- a/bluesky_config/tiled/tld.yml
+++ b/bluesky_config/tiled/tld.yml
@@ -1,3 +1,4 @@
+# Tiled Server Config
 trees:
   - path: /
     tree: databroker.mongo_normalized:MongoAdapter.from_uri
@@ -6,7 +7,6 @@ trees:
 uvicorn:
   host: 0.0.0.0
   port: 8000
-  root_path: /tiled
 authentication:
   allow_anonymous_access: true
   single_user_api_key: "ABCDABCD"

--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -136,16 +136,19 @@ services:
       - ${BLUESKY_PROFILE_DIR:-../../bluesky_config/ipython/profile_default}:/usr/local/share/ipython/profile_qserver:ro
       - ../../bluesky_config/databroker:/usr/local/share/intake:ro
       - ../../bluesky_config/ipython/localdevs.py:/usr/local/share/ipython/localdevs.py:ro
+      - ../../bluesky_config/databroker/mad-tiled.yml:/usr/etc/tiled/profiles/mad-tiled.yml:ro
       - ../../bluesky_config/happi:/usr/local/share/happi:ro
     depends_on:
       kafka:
+        condition: service_started
+      redis:
         condition: service_started
 
   qs_api:
     image: bluesky
     build: ../bluesky
     command: uvicorn --host qs_api --port 60610 bluesky_httpserver.server:app
-    env:
+    environment:
       - QSERVER_HTTP_SERVER_SINGLE_USER_API_KEY=mad
       - QSERVER_ZMQ_CONTROL_ADDRESS=tcp://queue_manager:60615
       - QSERVER_ZMQ_INFO_ADDRESS=tcp://queue_manager:60625

--- a/compose/acq-pod/launch_bluesky.sh
+++ b/compose/acq-pod/launch_bluesky.sh
@@ -67,8 +67,8 @@ podman run --pod pod_acq-pod  \
        -v `pwd`:'/app' -w '/app' \
        -v ${BLUESKY_PROFILE_DIR:-$parent_path/../../bluesky_config/ipython/profile_default}:/usr/local/share/ipython/profile_default \
        -v $parent_path/../../bluesky_config/ipython/localdevs.py:/usr/local/share/ipython/localdevs.py \
-       -v $parent_path/../../bluesky_config/databroker:/usr/local/share/intake \
-       -v $parent_path/../../bluesky_config/databroker/mad-tld.yml:/usr/etc/tiled/profiles/mad-tiled.yml \
+       -v $parent_path/../../bluesky_config/databroker/mad.yml:/usr/local/share/intake/mad.yml \
+       -v $parent_path/../../bluesky_config/databroker/mad-tiled.yml:/usr/etc/tiled/profiles/mad-tiled.yml \
        -v $parent_path/../../bluesky_config/happi:/usr/local/share/happi \
        -e XDG_RUNTIME_DIR=/tmp/runtime-$USER \
        -e EPICS_CA_ADDR_LIST=10.0.2.255 \

--- a/compose/acq-pod/launch_bluesky.sh
+++ b/compose/acq-pod/launch_bluesky.sh
@@ -68,6 +68,7 @@ podman run --pod pod_acq-pod  \
        -v ${BLUESKY_PROFILE_DIR:-$parent_path/../../bluesky_config/ipython/profile_default}:/usr/local/share/ipython/profile_default \
        -v $parent_path/../../bluesky_config/ipython/localdevs.py:/usr/local/share/ipython/localdevs.py \
        -v $parent_path/../../bluesky_config/databroker:/usr/local/share/intake \
+       -v $parent_path/../../bluesky_config/databroker/mad-tld.yml:/usr/etc/tiled/profiles/mad-tiled.yml \
        -v $parent_path/../../bluesky_config/happi:/usr/local/share/happi \
        -e XDG_RUNTIME_DIR=/tmp/runtime-$USER \
        -e EPICS_CA_ADDR_LIST=10.0.2.255 \

--- a/compose/bluesky/Containerfile
+++ b/compose/bluesky/Containerfile
@@ -13,6 +13,6 @@ RUN pip3 install git+https://github.com/bluesky/bluesky-httpserver.git@master#eg
 RUN pip3 install git+https://github.com/bluesky/bluesky-widgets.git@master#egg=bluesky-widgets
 RUN pip3 install git+https://github.com/pcdshub/happi.git@master#egg=happi
 RUN pip3 install tiled[all]
-RUN pip3 install --pre databroker
+RUN pip3 install --pre --upgrade databroker
 RUN pip3 install nslsii
 RUN pip3 uninstall --yes pyepics

--- a/compose/bluesky/Containerfile
+++ b/compose/bluesky/Containerfile
@@ -7,10 +7,12 @@ RUN mkdir /etc/bluesky
 ADD kafka.yml /etc/bluesky/kafka.yml
 RUN python3 -c "import matplotlib.font_manager"  # Build font cache.
 
-RUN pip3 install git+https://github.com/bluesky/bluesky-adaptive.git@main#egg=bluesky-adaptive
+RUN pip3 install git+https://github.com/bluesky/bluesky-adaptive.git@main#egg=bluesky-adaptive[all]
 RUN pip3 install git+https://github.com/bluesky/bluesky-queueserver.git@main#egg=bluesky-queueserver
 RUN pip3 install git+https://github.com/bluesky/bluesky-httpserver.git@master#egg=bluesky-httpserver
 RUN pip3 install git+https://github.com/bluesky/bluesky-widgets.git@master#egg=bluesky-widgets
 RUN pip3 install git+https://github.com/pcdshub/happi.git@master#egg=happi
+RUN pip3 install tiled[all]
+RUN pip3 install --pre databroker
 RUN pip3 install nslsii
 RUN pip3 uninstall --yes pyepics

--- a/compose/bluesky/Containerfile
+++ b/compose/bluesky/Containerfile
@@ -7,7 +7,7 @@ RUN mkdir /etc/bluesky
 ADD kafka.yml /etc/bluesky/kafka.yml
 RUN python3 -c "import matplotlib.font_manager"  # Build font cache.
 
-RUN pip3 install git+https://github.com/bluesky/bluesky-adaptive.git@main#egg=bluesky-adaptive[all]
+RUN pip3 install git+https://github.com/bluesky/bluesky-adaptive.git@main#egg=bluesky-adaptive
 RUN pip3 install git+https://github.com/bluesky/bluesky-queueserver.git@main#egg=bluesky-queueserver
 RUN pip3 install git+https://github.com/bluesky/bluesky-httpserver.git@master#egg=bluesky-httpserver
 RUN pip3 install git+https://github.com/bluesky/bluesky-widgets.git@master#egg=bluesky-widgets


### PR DESCRIPTION
Upgrade databroker to pre-release (v2), and update Tiled server and client configurations. This ensures that the `BlueskyRun` returned by `db` is the same as can be accessed from Tiled either by a uri, or by a new client profile.

Fixes some other minor typos that were causing failures. 

Tested with `Podman-compose --in-pod true up -d` then `bash launch_bluesky.sh`.