### PR TITLE
add: simple agent and bluesky adaptive functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ db[1] # or db[uid] can be used to access the data
 from tiled.client import from_profile, from_uri
 c = from_profile("MAD")
 c[1] # or c[uid]
-c = from_uri("http://tld:8000/")
+c = from_uri("http://proxy:11973/tiled")
 c[1] # or c[uid]
 ```
 

--- a/bluesky_config/ipython/profile_default/startup/00-base.py
+++ b/bluesky_config/ipython/profile_default/startup/00-base.py
@@ -17,6 +17,7 @@ from bluesky.callbacks.best_effort import BestEffortCallback
 from bluesky.callbacks.zmq import Publisher as zmqPublisher
 from bluesky.plans import *
 from bluesky_kafka import Publisher as kafkaPublisher
+from bluesky_queueserver import is_re_worker_active
 
 # from bluesky_adaptive.per_start import adaptive_plan # This is incompatible with the queue-server (default args)
 
@@ -96,6 +97,8 @@ devs = {v.name: v for v in [happi.loader.from_container(_) for _ in hclient.all_
 
 if ip is not None:
     ip.user_ns.update(devs)
+elif is_re_worker_active():
+    globals().update(devs)
 
 # do from another
 # http POST 0.0.0.0:8081/add_to_queue plan:='{"plan":"scan", "args":[["det"], "motor", -1, 1, 10]}'

--- a/bluesky_config/nginx/index.html
+++ b/bluesky_config/nginx/index.html
@@ -1,28 +1,103 @@
-<html>
-  <head>
-<title>beamline-in-a-pod</title>
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Landing Page for Agent Services</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f0f0f0;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      text-align: center;
+    }
+
+    .container {
+      background-color: #ffffff;
+      padding: 20px;
+      border-radius: 5px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      margin: 10px;
+      width: 80%;
+      max-width: 800px;
+    }
+
+    h1 {
+      color: #333333;
+    }
+
+    p,
+    a {
+      color: #666666;
+    }
+
+    ul {
+      list-style-type: none;
+      padding: 0;
+    }
+
+    li {
+      margin: 10px 0;
+    }
+
+    a {
+      text-decoration: none;
+      color: #007BFF;
+    }
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    .container h2 {
+      margin-top: 0;
+    }
+  </style>
 </head>
+
 <body>
-<h1>beamline-in-a-pod</h1>
+  <div class="container">
+    <h1>beamline-in-a-pod</h1>
+    <h2>Jupyter</h2>
+    <ul>
+      <li><a href="jlab">Jupyter lab instance</a></li>
+    </ul>
 
-<h2>Jupyter</h2>
+    <h2>Tiled</h2>
+    <ul>
+      <li><a href="tiled/api/v1/">API endpoint</a></li>
+      <li><a href="tiled/ui/browse">User Interface</a></li>
+    </ul>
 
-<ul>
-  <li> <a href="jlab">Jupyter lab instance: </a>
-</ul>
+    <h2>QueueServer</h2>
+    <ul>
+      <li><a href="qs/api/">API endpoint</a></li>
+    </ul>
+  </div>
 
+  <div class="container">
+    <h1>Landing Page for Agent Services!</h1>
+    <p>This is the default landing page for the agent services.</p>
 
-<h2>Tiled</h2>
+    <h2>Available Agents (Swagger API)</h2>
+    <ul>
+      <li><a href="/reactive-agent/docs">Reactive Agent Service (FastAPI)</a></li>
+    </ul>
 
-<ul>
-  <li> <a href="tiled/api/v1/">API endpoint</a>
-   <li ><a href="tiled/ui/browse">User Interface</a>
-</ul>
+    <h2>Available Agent User Interfaces</h2>
+    <ul>
+      <li>Under development</li>
+    </ul>
 
-<h2>QueueServer</h2>
-<ul>
-  <li><a href="qs/api/">API endpoint</a>
-</ul>
-
+    <p>Click on the links above to access our services.</p>
+  </div>
 </body>
+
 </html>

--- a/bluesky_config/nginx/locs.d/reactive_agent.conf
+++ b/bluesky_config/nginx/locs.d/reactive_agent.conf
@@ -1,0 +1,10 @@
+location /reactive-agent/ {
+    proxy_pass http://reactive-agent:8000/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_read_timeout 60s;
+    proxy_connect_timeout 5s;
+    proxy_send_timeout 10s;
+    proxy_intercept_errors on;
+}

--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -172,6 +172,8 @@ services:
         condition: service_started
       tld:
         condition: service_started
+      reactive-agent:
+        condition: service_started
 
   reactive-agent:
     image: bluesky
@@ -182,8 +184,7 @@ services:
       - BS_AGENT_STARTUP_SCRIPT_PATH=/src/bluesky-adaptive/reactive_random_walk.py
     volumes:
       - ../bluesky-adaptive/:/src/bluesky-adaptive/:ro
+      - ../../bluesky_config/databroker/mad-tiled.yml:/usr/etc/tiled/profiles/mad-tiled.yml
     depends_on:
       qs_api:
-        condition: service_started
-      proxy:
         condition: service_started

--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -12,43 +12,43 @@ services:
   caproto-hello-world:
     image: caproto
     build: ../caproto
-    tty:
+    tty: true
     init: true
   caproto-0:
     image: caproto
     build: ../caproto
     command: python3 -m caproto.ioc_examples.mini_beamline -v
-    tty:
+    tty: true
     init: true
   caproto-1:
     image: caproto
     build: ../caproto
     command: python3 -m caproto.ioc_examples.random_walk -v
-    tty:
+    tty: true
     init: true
   caproto-2:
     image: caproto
     build: ../caproto
     command: python3 -m caproto.ioc_examples.random_walk -v  --prefix="random_walk:horiz-"
-    tty:
+    tty: true
     init: true
   caproto-3:
     image: caproto
     build: ../caproto
     command: python3 -m caproto.ioc_examples.random_walk -v  --prefix="random_walk:vert-"
-    tty:
+    tty: true
     init: true
   caproto-4:
     image: caproto
     build: ../caproto
     command: python3 -m caproto.ioc_examples.simple -v
-    tty:
+    tty: true
     init: true
   caproto-5:
     image: caproto
     build: ../caproto
     command: python3 -m caproto.ioc_examples.thermo_sim -v
-    tty:
+    tty: true
     init: true
 
   # zmq bridge

--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -83,7 +83,7 @@ services:
   # mongo
   mongo:
     image: docker.io/library/mongo:latest
-    tty:
+    tty: true
     volumes:
       - mongo:/data/db
 

--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -172,3 +172,18 @@ services:
         condition: service_started
       tld:
         condition: service_started
+
+  reactive-agent:
+    image: bluesky
+    command: uvicorn bluesky_adaptive.server:app --host 0.0.0.0 --root-path /reactive-agent
+    environment:
+      - TILED_API_KEY="ABCDABCD"
+      - HTTPSERVER_API_KEY=mad
+      - BS_AGENT_STARTUP_SCRIPT_PATH=/src/bluesky-adaptive/reactive_random_walk.py
+    volumes:
+      - ../bluesky-adaptive/:/src/bluesky-adaptive/:ro
+    depends_on:
+      qs_api:
+        condition: service_started
+      proxy:
+        condition: service_started

--- a/compose/acq-pod/launch_bluesky.sh
+++ b/compose/acq-pod/launch_bluesky.sh
@@ -36,6 +36,19 @@ else
 fi
 xauth nlist $LOCAL_DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
+# Get the IP adresses of all caproto IOC containers
+containers=$(podman ps --filter name=caproto --format "{{.Names}}")
+ca_containers=($containers)
+EPICS_CA_ADDR_LIST=""
+
+for container in "${ca_containers[@]}"; do
+    container_ip=$(podman inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container")
+    echo "Adding $container_ip to EPICS_CA_ADDR_LIST"
+    EPICS_CA_ADDR_LIST="$EPICS_CA_ADDR_LIST $container_ip"
+done
+EPICS_CA_ADDR_LIST=$(echo "$EPICS_CA_ADDR_LIST" | xargs)
+EPICS_CA_ADDR_LIST="'$EPICS_CA_ADDR_LIST'"
+
 # https://stackoverflow.com/questions/24112727/relative-paths-based-on-file-location-instead-of-current-working-directory
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
@@ -55,7 +68,7 @@ else
     CMD="ipython3 --ipython-dir=/usr/local/share/ipython"
 fi
 
-
+#TODO (maffettone): fix EPICS_CA_ADDR_LIST
 podman run --pod pod_acq-pod  \
        --net acq-pod_default \
        --network-alias sneaky \
@@ -71,7 +84,7 @@ podman run --pod pod_acq-pod  \
        -v $parent_path/../../bluesky_config/databroker/mad-tiled.yml:/usr/etc/tiled/profiles/mad-tiled.yml \
        -v $parent_path/../../bluesky_config/happi:/usr/local/share/happi \
        -e XDG_RUNTIME_DIR=/tmp/runtime-$USER \
-       -e EPICS_CA_ADDR_LIST=10.0.2.255 \
+       -e EPICS_CA_ADDR_LIST="10.89.0.151 10.89.0.152 10.89.0.153 10.89.0.154 10.89.0.155 10.89.0.156 10.89.0.157" \
        -e EPICS_CA_AUTO_ADDR_LIST=no \
        -e PYTHONPATH=/usr/local/share/ipython\
        -e QSERVER_ZMQ_CONTROL_ADDRESS=tcp://queue_manager:60615\

--- a/compose/acq-pod/launch_bluesky.sh
+++ b/compose/acq-pod/launch_bluesky.sh
@@ -36,16 +36,45 @@ else
 fi
 xauth nlist $LOCAL_DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
-# Get the IP adresses of all caproto IOC containers
+# Get the IP adresses of all caproto IOC containers; and list unique broadcast addresses. Should only be one.
+# No assumption of ipcalc being available.
+# Functions to convert an IP address to binary and back
+ip_to_bin() {
+    local ip="$1"
+    IFS=. read -r a b c d <<< "$ip"
+    printf "%08d%08d%08d%08d\n" "$(bc <<< "obase=2; $a")" "$(bc <<< "obase=2; $b")" "$(bc <<< "obase=2; $c")" "$(bc <<< "obase=2; $d")"
+}
+bin_to_ip() {
+    local bin="$1"
+    echo "$((2#${bin:0:8})).$((2#${bin:8:8})).$((2#${bin:16:8})).$((2#${bin:24:8}))"
+}
 containers=($(podman ps --filter name=caproto --format "{{.Names}}"))
 EPICS_CA_ADDR_LIST=""
-
+broadcasts=()
 for container in "${containers[@]}"; do
-    container_ip=$(podman inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container")
-    echo "Adding $container_ip to EPICS_CA_ADDR_LIST"
-    EPICS_CA_ADDR_LIST="$EPICS_CA_ADDR_LIST $container_ip"
+    ip_address=$(podman inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container")
+    subnet_len=$(podman inspect -f '{{range .NetworkSettings.Networks}}{{.IPPrefixLen}}{{end}}' "$container")
+    # Calculate the network mask in binary
+    subnet_mask_bin=$(printf "%-32s" $(head -c $subnet_len < /dev/zero | tr '\0' '1'))
+    subnet_mask_bin="${subnet_mask_bin// /0}"
+    # Calculate the inverted subnet mask
+    inv_subnet_mask_bin=$(echo "$subnet_mask_bin" | tr '01' '10')
+    # Convert the IP address to binary
+    ip_address_bin=$(ip_to_bin "$ip_address")
+    # Calculate the network address (bitwise AND)
+    network_address_bin=$(echo "$ip_address_bin" | awk -v mask="$subnet_mask_bin" '{for(i=1;i<=32;i++)printf "%d", substr($0,i,1) * substr(mask,i,1)}')
+    # Calculate the broadcast address (bitwise OR with inverted subnet mask)
+    broadcast_address_bin=$(echo "$network_address_bin" | awk -v inv_mask="$inv_subnet_mask_bin" '{for(i=1;i<=32;i++)printf "%d", substr($0,i,1) + substr(inv_mask,i,1)}')
+    # Convert the broadcast address to a readable IP address
+    broadcast_address=$(bin_to_ip "$broadcast_address_bin")
+    broadcasts+=($broadcast_address)
+done
+uniques=($(for v in "${broadcasts[@]}"; do echo "$v";done| sort| uniq| xargs))
+for addr in "${uniques[@]}"; do
+    EPICS_CA_ADDR_LIST="$EPICS_CA_ADDR_LIST $addr"
 done
 EPICS_CA_ADDR_LIST="${EPICS_CA_ADDR_LIST:1}"
+echo "EPICS_CA_ADDR_LIST=$EPICS_CA_ADDR_LIST"
 
 # https://stackoverflow.com/questions/24112727/relative-paths-based-on-file-location-instead-of-current-working-directory
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )

--- a/compose/acq-pod/launch_bluesky.sh
+++ b/compose/acq-pod/launch_bluesky.sh
@@ -37,17 +37,15 @@ fi
 xauth nlist $LOCAL_DISPLAY | sed -e 's/^..../ffff/' | xauth -f $XAUTH nmerge -
 
 # Get the IP adresses of all caproto IOC containers
-containers=$(podman ps --filter name=caproto --format "{{.Names}}")
-ca_containers=($containers)
+containers=($(podman ps --filter name=caproto --format "{{.Names}}"))
 EPICS_CA_ADDR_LIST=""
 
-for container in "${ca_containers[@]}"; do
+for container in "${containers[@]}"; do
     container_ip=$(podman inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$container")
     echo "Adding $container_ip to EPICS_CA_ADDR_LIST"
     EPICS_CA_ADDR_LIST="$EPICS_CA_ADDR_LIST $container_ip"
 done
-EPICS_CA_ADDR_LIST=$(echo "$EPICS_CA_ADDR_LIST" | xargs)
-EPICS_CA_ADDR_LIST="'$EPICS_CA_ADDR_LIST'"
+EPICS_CA_ADDR_LIST="${EPICS_CA_ADDR_LIST:1}"
 
 # https://stackoverflow.com/questions/24112727/relative-paths-based-on-file-location-instead-of-current-working-directory
 parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
@@ -68,7 +66,7 @@ else
     CMD="ipython3 --ipython-dir=/usr/local/share/ipython"
 fi
 
-#TODO (maffettone): fix EPICS_CA_ADDR_LIST
+
 podman run --pod pod_acq-pod  \
        --net acq-pod_default \
        --network-alias sneaky \
@@ -84,7 +82,7 @@ podman run --pod pod_acq-pod  \
        -v $parent_path/../../bluesky_config/databroker/mad-tiled.yml:/usr/etc/tiled/profiles/mad-tiled.yml \
        -v $parent_path/../../bluesky_config/happi:/usr/local/share/happi \
        -e XDG_RUNTIME_DIR=/tmp/runtime-$USER \
-       -e EPICS_CA_ADDR_LIST="10.89.0.151 10.89.0.152 10.89.0.153 10.89.0.154 10.89.0.155 10.89.0.156 10.89.0.157" \
+       -e EPICS_CA_ADDR_LIST="${EPICS_CA_ADDR_LIST}" \
        -e EPICS_CA_AUTO_ADDR_LIST=no \
        -e PYTHONPATH=/usr/local/share/ipython\
        -e QSERVER_ZMQ_CONTROL_ADDRESS=tcp://queue_manager:60615\

--- a/compose/bluesky-adaptive/reactive_random_walk.py
+++ b/compose/bluesky-adaptive/reactive_random_walk.py
@@ -1,0 +1,215 @@
+import logging
+import os
+import uuid
+from abc import ABC
+from typing import Dict
+
+import numpy as np
+from bluesky_adaptive.agents.base import Agent, AgentConsumer
+from bluesky_adaptive.server import register_variable, shutdown_decorator, startup_decorator
+from bluesky_queueserver_api.http import REManagerAPI
+from databroker.client import BlueskyRun
+from tiled.client import from_uri
+
+logger = logging.getLogger(__name__)
+
+
+def perlin(x, y, seed=0):
+    """Perlin noise implementation.
+    https://stackoverflow.com/questions/42147776/producing-2d-perlin-noise-with-numpy
+    """
+
+    def lerp(a, b, x):
+        "linear interpolation"
+        return a + x * (b - a)
+
+    def fade(t):
+        "6t^5 - 15t^4 + 10t^3"
+        return 6 * t**5 - 15 * t**4 + 10 * t**3
+
+    def gradient(h, x, y):
+        "grad converts h to the right gradient vector and return the dot product with (x,y)"
+        vectors = np.array([[0, 1], [0, -1], [1, 0], [-1, 0]])
+        g = vectors[h % 4]
+        return g[:, :, 0] * x + g[:, :, 1] * y
+
+    # permutation table
+    np.random.seed(seed)
+    p = np.arange(256, dtype=int)
+    np.random.shuffle(p)
+    p = np.stack([p, p]).flatten()
+    # coordinates of the top-left
+    xi, yi = x.astype(int), y.astype(int)
+    # internal coordinates
+    xf, yf = x - xi, y - yi
+    # fade factors
+    u, v = fade(xf), fade(yf)
+    # noise components
+    n00 = gradient(p[p[xi] + yi], xf, yf)
+    n01 = gradient(p[p[xi] + yi + 1], xf, yf - 1)
+    n11 = gradient(p[p[xi + 1] + yi + 1], xf - 1, yf - 1)
+    n10 = gradient(p[p[xi + 1] + yi], xf - 1, yf)
+    # combine noises
+    x1 = lerp(n00, n10, u)
+    x2 = lerp(n01, n11, u)
+    return lerp(x1, x2, v)
+
+
+class PodBaseAgent(Agent, ABC):
+    def __init__(self, *args, metadata=None, **kwargs):
+        metadata = metadata or {}
+        _default_kwargs = self.get_beamline_objects()
+        _default_kwargs.update(kwargs)
+        super().__init__(*args, metadata=metadata, **_default_kwargs)
+
+    @staticmethod
+    def get_beamline_objects():
+        qs = REManagerAPI(http_server_uri="http://qs_api:60610")
+        qs.set_authorization_key(api_key=os.getenv("HTTPSERVER_API_KEY", "mad"))
+        kafka_consumer = AgentConsumer(
+            topics=[
+                "mad.bluesky.documents",
+            ],
+            consumer_config={"auto.offset.reset": "earliest"},
+            bootstrap_servers="kafka:29092",
+            group_id=f"echo-{str(uuid.uuid4())[:8]}",
+        )
+        return dict(
+            kafka_consumer=kafka_consumer,
+            kafka_producer=None,
+            tiled_data_node=from_uri("http://proxy:11973/tiled", api_key="ABCDABCD"),
+            tiled_agent_node=from_uri("http://proxy:11973/tiled", api_key="ABCDABCD"),
+            qserver=qs,
+        )
+
+
+class ReactiveAgent(Agent, ABC):
+    """Build the Logic for the Reactive Random Walk Agent, that reacts to an observable and increases or decreases
+    some position. This is only logic, but system agnostic."""
+
+    def __init__(self, *, target, step_size=0.1, **kwargs):
+        super().__init__(**kwargs)
+        self._target = target
+        self._step_size = step_size
+        self._last_value = None
+
+    @staticmethod
+    def _make_perlin_noise():
+        perlin_noise = np.zeros((100, 100))
+        for i in range(4):
+            freq = 2**i
+            lin = np.linspace(0, freq, 100, endpoint=False)
+            x, y = np.meshgrid(lin, lin)  # FIX3: I thought I had to invert x and y here but it was a mistake
+            perlin_noise = perlin(x, y, seed=None) / freq + perlin_noise
+        return perlin_noise
+
+    def tell(self, x, y):
+        self._last_value = y
+        return dict(independent_variable=x, observable=y)
+
+    def report(self, **kwargs) -> Dict:
+        return dict(
+            target=self._target,
+            step_size=self._step_size,
+            brain=self._make_perlin_noise(),
+        )
+
+    def ask(self, n):
+        super().ask(n)
+        """Generates a reactive walk, but logs some perlin noise as a proxy for decision logic"""
+        if self._last_value is None:
+            return (
+                [
+                    dict(
+                        target=self._target,
+                        step_size=self._step_size,
+                        next_value=0.0,
+                        brain=self._make_perlin_noise(),
+                    )
+                ],
+                [0.0],
+            )
+        elif self._last_value > self._target:
+            next_value = self._last_value - self._step_size
+            logger.info(f"Decreasing value from {self._last_value} to {next_value}")
+            return (
+                [
+                    dict(
+                        target=self._target,
+                        step_size=self._step_size,
+                        next_value=next_value,
+                        brain=self._make_perlin_noise(),
+                    )
+                ],
+                [next_value],
+            )
+        else:
+            next_value = self._last_value + self._step_size
+            logger.info(f"Increasing value from {self._last_value} to {next_value}")
+            return (
+                [
+                    dict(
+                        target=self._target,
+                        step_size=self._step_size,
+                        next_value=next_value,
+                        brain=self._make_perlin_noise(),
+                    )
+                ],
+                [next_value],
+            )
+
+    @property
+    def target(self):
+        return self._target
+
+    @target.setter
+    def target(self, value):
+        self._target = value
+
+    @property
+    def step_size(self):
+        return self._step_size
+
+    @step_size.setter
+    def step_size(self, value):
+        self._step_size = value
+
+    def server_registrations(self) -> None:
+        super().server_registrations()
+        self._register_property("target")
+        self._register_property("step_size")
+
+
+class ReactiveRandomWalker(ReactiveAgent, PodBaseAgent):
+    def __init__(self, *, detector="random_walk", read_key="random_walk_x", motor="motor", **kwargs):
+        self._detector = detector
+        self._motor = motor
+        self._read_key = read_key
+        super().__init__(**kwargs)
+
+    def unpack_run(self, run: BlueskyRun):
+        data = run.primary.data.read()
+        x = float(data[self._motor].data)
+        y = float(data[self._read_key].data)
+        return x, y
+
+    def measurement_plan(self, point):
+        return "scan", [[self._detector], self._motor, point, point, 1], {}
+
+
+# ==========================This is the necassary code to start the agent========================== #
+agent = ReactiveRandomWalker(target=np.random.rand(), ask_on_tell=False)
+
+
+@startup_decorator
+def startup():
+    agent.start()
+
+
+@shutdown_decorator
+def shutdown_agent():
+    return agent.stop()
+
+
+register_variable("Agent Name", agent, "instance_name")
+# ==========================This is the necassary code to start the agent========================== #


### PR DESCRIPTION
This adds a simple agent to work with the caproto backed random walk. It performs some trivial and useless logic on top of scans of the random walk device. It publishes a random Perlin image as its "brain" to demonstrate how to log internals of an agent into tiled. 

## Some other fixes and maintenance to make this possible.
- Docker compose lint
- qserver compatibility with Happi
- polish the index.html landing page
- explicitly labeling the caproto services as `EPICS_CA_ADDR_LIST` in bluesky launch file. 