### PR TITLE
Update docs to include bug workaround in podman-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ instance running the pod which are proxied via nginx.  If the pod is running
 `http://localhost:11973` will provide links to each.
 
 ## Notes
+
 If using a version of `podman-compose` between 1.1 and 1.2 there is a bug that has been [fixed](https://github.com/containers/podman-compose/pull/978), but not yet released.
 For a work around, rename the `Containerfile` to `Dockerfile` and use podman-compose. 
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ There is a jupyterlab instance, a tiled instance, and a Queueserver http API
 instance running the pod which are proxied via nginx.  If the pod is running
 `http://localhost:11973` will provide links to each.
 
+## Notes
+If using a version of podman between 1.1 and 1.2 there is a bug that has been [fixed](https://github.com/containers/podman-compose/pull/978), but not yet released.
+For a work around, rename the `Containerfile` to `Dockerfile` and use podman-compose. 
 
 ## Terms
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ instance running the pod which are proxied via nginx.  If the pod is running
 `http://localhost:11973` will provide links to each.
 
 ## Notes
-If using a version of podman between 1.1 and 1.2 there is a bug that has been [fixed](https://github.com/containers/podman-compose/pull/978), but not yet released.
+If using a version of `podman-compose` between 1.1 and 1.2 there is a bug that has been [fixed](https://github.com/containers/podman-compose/pull/978), but not yet released.
 For a work around, rename the `Containerfile` to `Dockerfile` and use podman-compose. 
 
 ## Terms


### PR DESCRIPTION
Using podman-compose with a version between 1.1 and 1.2 does not allow use for `Dockerfiles`. Bug is fixed but not released. See here: https://github.com/containers/podman-compose/pull/978