### PR TITLE
fix: bluesky image dependencies and installs

### DIFF
--- a/bluesky_config/ipython/localdevs.py
+++ b/bluesky_config/ipython/localdevs.py
@@ -1,11 +1,11 @@
 """Special use handler for training."""
+
+import threading
 import numpy as np
 
 from ophyd import Device, Component as Cpt, Signal, DeviceStatus
 from ophyd.device import Staged
 from ophyd.signal import EpicsSignal, EpicsSignalRO
-
-from nslsii.temperature_controllers import Eurotherm
 
 
 class NewtonDirectSimulator(Device):
@@ -36,7 +36,6 @@ class NewtonDirectSimulator(Device):
         return 1 + np.cos(phi)
 
     def _compute(self):
-
         self.image.put(self._newton(self.gap.get(), self._R, self._k))
 
     def __init__(self, R, k, **kwargs):
@@ -73,6 +72,115 @@ class Spot(Device):
         return self.img.trigger()
 
 
+class SetInProgress(RuntimeError): ...
+
+
+class Eurotherm(Device):
+    """
+    Copied from nslsii package to remove dependency on nslsii.
+
+    This class is used for integrating with Eurotherm controllers.
+
+    This is used for Eurotherm controllers and is designed to ensure that the
+    set returns 'done' status only after the temperature has reached
+    equilibrium at the required value not when it first reaches the required
+    value. This is done via the attributes `self.equilibrium_time` and
+    `self.tolerance`. It only returns `done` if `self.readback` remains within
+    `self.tolerance` of `self.setpoint` over `self.equilibrium_time`. A third
+    attribute, `self.timeout`, is used to determeine the maximum time to wait
+    for equilibrium. If it takes longer than this it raises a TimeoutError.
+
+    Parameters
+    ----------
+    pv_prefix : str.
+        The PV prefix that is common to the readback and setpoint PV's.
+    """
+
+    def __init__(self, pv_prefix, **kwargs):
+        super().__init__(pv_prefix, **kwargs)
+        self._set_lock = threading.Lock()
+
+        # defining these here so that they can be used by `set` and `start`
+        self._cb_timer = None
+        self._cid = None
+
+    # Setup some new signals required for the moving indicator logic
+    equilibrium_time = Cpt(Signal, value=5, kind="config")
+    timeout = Cpt(Signal, value=500, kind="config")
+    tolerance = Cpt(Signal, value=1, kind="config")
+
+    # Add the readback and setpoint components
+    setpoint = Cpt(EpicsSignal, "T-SP", kind="normal")
+    readback = Cpt(EpicsSignal, "T-RB", kind="hinted")
+
+    # define the new set method with the new moving indicator
+    def set(self, value):
+        # check that a set is not in progress, and if not set the lock.
+        if not self._set_lock.acquire(blocking=False):
+            raise SetInProgress(
+                "attempting to set {} ".format(self.name) + "while a set is in progress"
+            )
+
+        # define some required values
+        set_value = value
+        status = DeviceStatus(self)
+
+        initial_timestamp = None
+
+        # grab these values here to avoidmutliple calls.
+        equilibrium_time = self.equilibrium_time.get()
+        tolerance = self.tolerance.get()
+
+        # setup a cleanup function for the timer, this matches including
+        # timeout in `status` but also ensures that the callback is removed.
+        def timer_cleanup():
+            print(
+                "Set of {} timed out after {} s".format(self.name, self.timeout.get())
+            )
+            self._set_lock.release()
+            self.readback.clear_sub(status_indicator)
+            status._finished(success=False)
+
+        self._cb_timer = threading.Timer(self.timeout.get(), timer_cleanup)
+
+        # set up the done moving indicator logic
+        def status_indicator(value, timestamp, **kwargs):
+            # add a Timer to ensure that timeout occurs.
+            if not self._cb_timer.is_alive():
+                self._cb_timer.start()
+
+            nonlocal initial_timestamp
+            if abs(value - set_value) < tolerance:
+                if initial_timestamp:
+                    if (timestamp - initial_timestamp) > equilibrium_time:
+                        status._finished()
+                        self._cb_timer.cancel()
+                        self._set_lock.release()
+                        self.readback.clear_sub(status_indicator)
+                else:
+                    initial_timestamp = timestamp
+            else:
+                initial_timestamp = None
+
+        # Start the move.
+        self.setpoint.put(set_value)
+
+        # subscribe to the read value to indicate the set is done.
+        self._cid = self.readback.subscribe(status_indicator)
+
+        # hand the status object back to the RE
+        return status
+
+    def stop(self, success=False):
+        # overide the lock, cancel the timer and remove the subscription on any
+        # in progress sets
+        self._set_lock.release()
+        self._cb_timer.cancel()
+        self.readback.unsubscribe(self._cid)
+        # set the controller to the current value (best option we came up with)
+        self.set(self.readback.get())
+
+
 class Thermo(Eurotherm):
     # override these signals to account for different PV names
     readback = Cpt(EpicsSignal, "I", kind="hinted")
@@ -82,11 +190,6 @@ class Thermo(Eurotherm):
     K = Cpt(EpicsSignal, "K", kind="config")
     omega = Cpt(EpicsSignal, "omega", kind="config")
     Tvar = Cpt(EpicsSignal, "Tvar", kind="config")
-
-    # override these to set kind correctly, delete when nslsii updated
-    equilibrium_time = Cpt(Signal, value=5, kind="config")
-    timeout = Cpt(Signal, value=500, kind="config")
-    tolerance = Cpt(Signal, value=1, kind="config")
 
 
 class RandomWalk(Device):
@@ -101,14 +204,14 @@ class Simple(Device):
 
 
 class TriggeredIOC(Device):
-    gain = Cpt(EpicsSignal, 'gain', kind='config')
-    exposure_time = Cpt(EpicsSignal, 'exposure_time', kind='config')
-    enabled = Cpt(EpicsSignal, 'enabled', kind='config')
-    enabled = Cpt(EpicsSignal, 'enabled', kind='config')
+    gain = Cpt(EpicsSignal, "gain", kind="config")
+    exposure_time = Cpt(EpicsSignal, "exposure_time", kind="config")
+    enabled = Cpt(EpicsSignal, "enabled", kind="config")
+    enabled = Cpt(EpicsSignal, "enabled", kind="config")
 
-    reading = Cpt(EpicsSignal, 'reading', kind='hinted')
+    reading = Cpt(EpicsSignal, "reading", kind="hinted")
 
-    acquire = Cpt(EpicsSignal, 'reading', kind='omitted', put_complete=True)
+    acquire = Cpt(EpicsSignal, "reading", kind="omitted", put_complete=True)
 
     def trigger(self, *args, **kwargs):
         return self.acquire.set(*args, **kwargs)

--- a/compose/bluesky/Containerfile
+++ b/compose/bluesky/Containerfile
@@ -10,10 +10,11 @@ RUN dnf -y update && \
 # Install UV from Astral
 RUN pip3 install uv
 
-# Use UV to accelerate Python package installations
-RUN uv pip install --system\
-    caproto[standard] jupyter httpie fastapi uvicorn[standard] bluesky-tiled-plugins\
-    python-jose[cryptography] passlib[bcrypt] pykafka confluent_kafka nslsii tiled[all] scikit-learn scipy
+# Use wheels for stable install of dependencies. Compilation with advancing fedora can cause issues.
+RUN pip3 install \
+    jupyter httpie fastapi uvicorn[standard] bluesky-tiled-plugins\
+    python-jose[cryptography] passlib[bcrypt] pykafka confluent_kafka tiled[all] scikit-learn scipy\
+    caproto[standard]!=1.2.0
 
 # Create a configuration directory and add configuration files
 RUN mkdir -p /etc/bluesky
@@ -23,14 +24,16 @@ ADD kafka.yml /etc/bluesky/kafka.yml
 RUN python3 -c "import matplotlib.font_manager"
 
 # Use UV for Bluesky and related dependencies
+RUN uv pip install --system git+https://github.com/bluesky/ophyd.git@main#egg=ophyd
+RUN uv pip install --system git+https://github.com/bluesky/bluesky.git@main#egg=bluesky
 RUN uv pip install --system git+https://github.com/bluesky/bluesky-adaptive.git@main#egg=bluesky-adaptive
 RUN uv pip install --system git+https://github.com/bluesky/bluesky-queueserver.git@main#egg=bluesky-queueserver
-RUN uv pip install --system git+https://github.com/bluesky/bluesky-httpserver.git@master#egg=bluesky-httpserver
+RUN uv pip install --system git+https://github.com/bluesky/bluesky-httpserver.git@main#egg=bluesky-httpserver
 RUN uv pip install --system git+https://github.com/bluesky/bluesky-widgets.git@master#egg=bluesky-widgets
 RUN uv pip install --system git+https://github.com/pcdshub/happi.git@master#egg=happi
-RUN uv pip install --system git+https://github.com/bluesky/databroker.git@v2.0.0b58#egg=databroker
+RUN uv pip install --system --pre 'databroker>=2.0.0b1,<3.0.0'
 
 
 # Remove unnecessary packages (if needed)
 RUN pip3 uninstall --yes pyepics
-RUN uv pip install --system json-rpc dash dash-daq requests
+RUN uv pip install --system json-rpc dash dash-daq requests qtpy


### PR DESCRIPTION
1. Drops nslsii dependency. It doesn't belong in a non-nsls-II product. 
2. Use wheels where possible with pip. `uv pip --system` will build from source, which can cause some problems with outdated C libraries on modern Fedora. 
3. Pin not equals for caproto bug recently introduced
4. Fix the databroker range to be dynamic
5. Adds bluesky and ophyd explicitly from main