### PR TITLE
feat: add mvp for agent dev

### DIFF
--- a/bluesky_config/tiled/tiled-direct.yml
+++ b/bluesky_config/tiled/tiled-direct.yml
@@ -1,0 +1,12 @@
+# Tiled Server Config with no root path, so no expected proxy.
+trees:
+  - path: /
+    tree: databroker.mongo_normalized:MongoAdapter.from_uri
+    args:
+      uri: mongodb://mongo:27017/mad-bluesky-documents
+uvicorn:
+  host: 0.0.0.0
+  port: 8000
+authentication:
+  allow_anonymous_access: true
+  single_user_api_key: "ABCDABCD"

--- a/compose/acq-pod/docker-compose.yaml
+++ b/compose/acq-pod/docker-compose.yaml
@@ -89,7 +89,7 @@ services:
     volumes:
       - data:/nsls2/data/mad
       - ../../bluesky_config/tiled:/usr/local/share/tiled
-    command: tiled serve config /usr/local/share/tiled
+    command: tiled serve config /usr/local/share/tiled/tld.yml
 
   # inserter
   mongo_inserter:

--- a/compose/bluesky-adaptive/README.md
+++ b/compose/bluesky-adaptive/README.md
@@ -1,0 +1,34 @@
+# Bluesky Adaptive Agents
+
+## File contents
+
+- `reactive_random_walk.py`: a simpple reactive random walk agent that can be used to test the full stack in the acq-pod.
+- `mock_agent.py`: a mock agent that can be used in isolation to build against adaptive. This can be used with Tiled or without by setting the `USE_TILED` environment variable.
+
+## Running the mock agent in isolation
+
+Navigating to this directory and running the following command will start the mock agent in a container.
+The agent will be available at `http://localhost:8000`, with the swagger UI at `http://localhost:8000/docs`.
+It will not be particularly interactive, but it will respond to requests and can be used to test UI communication.
+
+```bash
+cd compose/bluesky-adaptive
+podman run --rm \
+    -v $(pwd):/src/bluesky-adaptive \
+    -e BS_AGENT_STARTUP_SCRIPT_PATH=/src/bluesky-adaptive/mock_agent.py \
+    -e USE_TILED=0 \
+    -p 8000:8000 \
+    bluesky:latest \
+    uvicorn bluesky_adaptive.server:app --host 0.0.0.0 --port 8000
+```
+
+## Running the mock agent without experiment orchestration
+
+To run the mock agent with only a tiled server and database (to write state/reports to), you can use the compose file in this directory.
+
+```bash
+cd compose/bluesky-adaptive
+podman-compose -f compose.yaml up -d
+```
+
+This will start the tiled server and database, and the mock agent will be available at `http://localhost:8000` with the swagger UI at `http://localhost:8000/docs`.

--- a/compose/bluesky-adaptive/compose.yaml
+++ b/compose/bluesky-adaptive/compose.yaml
@@ -1,0 +1,44 @@
+# Compose an agent, tiled server, and database on the same network.
+
+version: '3'
+
+volumes:
+  mongo:
+  data:
+
+networks:
+  mock_agent:
+    driver: bridge
+
+services:
+  mongo:
+    image: docker.io/library/mongo:latest
+    volumes:
+      - mongo:/data/db
+    networks:
+      - mock_agent
+
+  tiled:
+    image: sub-tiled
+    build: ../sub-tiled
+    volumes:
+      - data:/nsls2/data/mad
+      - ../../bluesky_config/tiled:/usr/local/share/tiled
+    networks:
+      - mock_agent
+    command: tiled serve config /usr/local/share/tiled/tiled-direct.yml
+
+  mock_agent:
+    image: bluesky
+    build: ../bluesky
+    environment:
+      - USE_TILED=true
+      - BS_AGENT_STARTUP_SCRIPT_PATH=/src/bluesky-adaptive/mock_agent.py
+    ports:
+      - "8080:8000"
+    volumes:
+      - ./mock_agent.py:/src/bluesky-adaptive/mock_agent.py
+    networks:
+      - mock_agent
+    command: uvicorn bluesky_adaptive.server:app --host 0.0.0.0 --port 8000
+  

--- a/compose/bluesky-adaptive/mock_agent.py
+++ b/compose/bluesky-adaptive/mock_agent.py
@@ -1,0 +1,108 @@
+import logging
+import os
+
+import numpy as np
+
+from bluesky_adaptive.utils.offline import OfflineAgent
+from bluesky_adaptive.agents.sklearn import ClusterAgentBase
+from bluesky_adaptive.server import (
+    register_variable,
+    shutdown_decorator,
+    startup_decorator,
+)
+from tiled.client import from_profile, from_uri
+from httpx import ConnectError, HTTPStatusError
+
+from sklearn.cluster import KMeans
+
+logger = logging.getLogger(__name__)
+
+
+class ClusterAgentMock(ClusterAgentBase, OfflineAgent):
+    """Mock agent for testing purposes. Inherits from ClusterAgentBase and OfflineAgent."""
+
+    def __init__(self, k_clusters: int, *args, use_tiled: bool = False, **kwargs):
+        """Initialize the mock agent with optional metadata.
+        Parameters
+        ----------
+        use_tiled : bool, optional
+            Whether to use Tiled for writing agent data to storage, by default False.
+            Does not read exp data from storage regardless.
+        """
+        estimator = KMeans(k_clusters, n_init="auto", random_state=42)
+        if use_tiled:
+            logger.info("Using Tiled for agent data storage.")
+            try:
+                tiled_container = from_uri("http://tiled:8000", api_key="ABCDABCD")
+            except ConnectError or HTTPStatusError:
+                tiled_container = from_profile("MAD")
+            kwargs["tiled_agent_node"] = tiled_container
+        super().__init__(
+            *args,
+            estimator=estimator,
+            loop_consumer_on_start=True,
+            **kwargs,
+        )
+
+    @property
+    def name(self) -> str:
+        """Short string name"""
+        return "MockClusterAgent"
+
+    # ==========================Useful behavior for clustering, caching, restarting ========================== #
+    def clear_caches(self):
+        self.independent_cache = []
+        self.dependent_cache = []
+
+    def close_and_restart(self, *, clear_tell_cache=False, retell_all=False, reason=""):
+        if clear_tell_cache:
+            self.clear_caches()
+        return super().close_and_restart(
+            clear_tell_cache=clear_tell_cache, retell_all=retell_all, reason=reason
+        )
+
+    @property
+    def n_clusters(self):
+        return self.model.n_clusters
+
+    @n_clusters.setter
+    def n_clusters(self, value):
+        self.model.set_params(n_clusters=int(value))
+        self.close_and_restart()
+
+    def server_registrations(self) -> None:
+        self._register_method("clear_caches")
+        self._register_property("n_clusters")
+        return super().server_registrations()
+
+    # ==========================Useful behavior for clustering, caching, restarting ========================== #
+
+    def unpack_run(self, *args, **kwargs):
+        """Mock unpack run method for clustering that returns a [2,] array for x and a [1, 10] array for y."""
+        x = np.random.rand(2)
+        y = np.random.rand(1, 10)
+        return x, y
+
+    def measurement_plan(self, point):
+        """Mock simply acceptable measurement plan, that as is, is not used."""
+        return "scan", [["random_walk"], "random_walk_k", 0.0, 1.0, 1], {}
+
+
+# ==========================This is the necessary code to start the agent========================== #
+
+use_tiled = os.getenv("USE_TILED", None) in (True, "yes", 1, "True", "true") or False
+agent = ClusterAgentMock(k_clusters=3, use_tiled=use_tiled)
+
+
+@startup_decorator
+def startup():
+    agent.start()
+
+
+@shutdown_decorator
+def shutdown_agent():
+    return agent.stop()
+
+
+register_variable("Agent Name", agent, "instance_name")
+# ==========================This is the necessary code to start the agent========================== #

--- a/compose/bluesky/Containerfile
+++ b/compose/bluesky/Containerfile
@@ -31,7 +31,9 @@ RUN uv pip install --system git+https://github.com/bluesky/bluesky-queueserver.g
 RUN uv pip install --system git+https://github.com/bluesky/bluesky-httpserver.git@main#egg=bluesky-httpserver
 RUN uv pip install --system git+https://github.com/bluesky/bluesky-widgets.git@master#egg=bluesky-widgets
 RUN uv pip install --system git+https://github.com/pcdshub/happi.git@master#egg=happi
-RUN uv pip install --system --pre 'databroker>=2.0.0b1,<3.0.0'
+
+# Use Wheels for databroker and related dependencies
+RUN pip3 install --pre 'databroker[all]>=2.0.0b1,<3.0.0'
 
 
 # Remove unnecessary packages (if needed)


### PR DESCRIPTION
This also updates the bluesky image to include the full dependency stack for databroker.

This provides a mechanism to have a complete mock agent, or have a partial mock that writes to a tiled service. 