### PR TITLE
fix: syntax error in close_and_restart

### DIFF
--- a/compose/bluesky-adaptive/mock_agent.py
+++ b/compose/bluesky-adaptive/mock_agent.py
@@ -54,11 +54,11 @@ class ClusterAgentMock(ClusterAgentBase, OfflineAgent):
         self.independent_cache = []
         self.dependent_cache = []
 
-    def close_and_restart(self, *, clear_tell_cache=False, retell_all=False, reason=""):
-        if clear_tell_cache:
+    def close_and_restart(self, *, clear_uid_cache=False, retell_all=False, reason=""):
+        if clear_uid_cache:
             self.clear_caches()
         return super().close_and_restart(
-            clear_tell_cache=clear_tell_cache, retell_all=retell_all, reason=reason
+            clear_uid_cache=clear_uid_cache, retell_all=retell_all, reason=reason
         )
 
     @property


### PR DESCRIPTION
This is to solve the error above
```python
[E 2025-06-11 19:02:21,974 bluesky_adaptive.server.server_api] Agent.close_and_restart() got an unexpected keyword argument 'clear_tell_cache'. Did you mean 'clear_uid_cache'?
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/bluesky_adaptive/server/server_api.py", line 103, in set_variable_handler
    return await SR.worker_set_variable(name=name, value=value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/bluesky_adaptive/server/server_resources.py", line 57, in worker_set_variable
    raise RequestFailedError(result["msg"])
bluesky_adaptive.server.comms.RequestFailedError: Agent.close_and_restart() got an unexpected keyword argument 'clear_tell_cache'. Did you mean 'clear_uid_cache'?
INFO:     10.88.0.1:33888 - "POST /api/variable/n_clusters HTTP/1.1" 500 Internal Server Error
INFO:     10.88.0.1:50120 - "GET /api/variables/names HTTP/1.1" 200 OK
INFO:     10.88.0.1:45100 - "GET /api/n_clusters HTTP/1.1" 404 Not Found
INFO:     10.88.0.1:45108 - "GET /api/variable/n_clusters HTTP/1.1" 200 OK
[E 2025-06-11 19:09:39,038 bluesky_adaptive.server.server_api] Agent.close_and_restart() got an unexpected keyword argument 'clear_tell_cache'. Did you mean 'clear_uid_cache'?
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/bluesky_adaptive/server/server_api.py", line 103, in set_variable_handler
    return await SR.worker_set_variable(name=name, value=value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/bluesky_adaptive/server/server_resources.py", line 57, in worker_set_variable
    raise RequestFailedError(result["msg"])
bluesky_adaptive.server.comms.RequestFailedError: Agent.close_and_restart() got an unexpected keyword argument 'clear_tell_cache'. Did you mean 'clear_uid_cache'?
INFO:     10.88.0.1:41342 - "POST /api/variable/n_clusters HTTP/1.1" 500 Internal Server Error
```