### PR TITLE
fix: syntax error in close_and_restart for reingest_all

### DIFF
--- a/compose/bluesky-adaptive/mock_agent.py
+++ b/compose/bluesky-adaptive/mock_agent.py
@@ -54,11 +54,11 @@ class ClusterAgentMock(ClusterAgentBase, OfflineAgent):
         self.independent_cache = []
         self.dependent_cache = []
 
-    def close_and_restart(self, *, clear_uid_cache=False, retell_all=False, reason=""):
+    def close_and_restart(self, *, clear_uid_cache=False, reingest_all=False, reason=""):
         if clear_uid_cache:
             self.clear_caches()
         return super().close_and_restart(
-            clear_uid_cache=clear_uid_cache, retell_all=retell_all, reason=reason
+            clear_uid_cache=clear_uid_cache, reingest_all=reingest_all, reason=reason
         )
 
     @property


### PR DESCRIPTION
```python 
[E 2025-06-12 13:22:28,195 bluesky_adaptive.server.server_api] Agent.close_and_restart() got an unexpected keyword argument 'retell_all'
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/bluesky_adaptive/server/server_api.py", line 103, in set_variable_handler
    return await SR.worker_set_variable(name=name, value=value)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/bluesky_adaptive/server/server_resources.py", line 57, in worker_set_variable
    raise RequestFailedError(result["msg"])
bluesky_adaptive.server.comms.RequestFailedError: Agent.close_and_restart() got an unexpected keyword argument 'retell_all'
INFO:     10.88.0.1:48058 - "POST /api/variable/n_clusters HTTP/1.1" 500 Internal Server Error
```