### PR TITLE
fix: dns collision and healthcheck

### DIFF
--- a/compose/bluesky-adaptive/compose.yaml
+++ b/compose/bluesky-adaptive/compose.yaml
@@ -1,6 +1,6 @@
 # Compose an agent, tiled server, and database on the same network.
 
-version: '3'
+version: "3"
 
 volumes:
   mongo:
@@ -18,15 +18,23 @@ services:
     networks:
       - mock_agent
 
-  tiled:
+  tiled_local:
     image: sub-tiled
     build: ../sub-tiled
+    ports:
+      - 8000:8000
     volumes:
       - data:/nsls2/data/mad
       - ../../bluesky_config/tiled:/usr/local/share/tiled
     networks:
       - mock_agent
     command: tiled serve config /usr/local/share/tiled/tiled-direct.yml
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
 
   mock_agent:
     image: bluesky
@@ -40,5 +48,7 @@ services:
       - ./mock_agent.py:/src/bluesky-adaptive/mock_agent.py
     networks:
       - mock_agent
+    depends_on:
+      tiled_local:
+        condition: service_healthy
     command: uvicorn bluesky_adaptive.server:app --host 0.0.0.0 --port 8000
-  

--- a/compose/bluesky-adaptive/mock_agent.py
+++ b/compose/bluesky-adaptive/mock_agent.py
@@ -33,7 +33,9 @@ class ClusterAgentMock(ClusterAgentBase, OfflineAgent):
         if use_tiled:
             logger.info("Using Tiled for agent data storage.")
             try:
-                tiled_container = from_uri("http://tiled:8000", api_key="ABCDABCD")
+                tiled_container = from_uri(
+                    "http://tiled_local:8000", api_key="ABCDABCD"
+                )
             except ConnectError or HTTPStatusError:
                 tiled_container = from_profile("MAD")
             kwargs["tiled_agent_node"] = tiled_container


### PR DESCRIPTION
Previously this test pod would result in some confusing DNS collisions on hosts that had a Tiled server running on network. 

Rather than over-prescribing the DNS and network configuration of the compose, we can just use a more unique name for the local service.

This also adds a healthcheck to start the agent AFTER the Tiled server is up and healthy. 